### PR TITLE
[FIX] Corrected HDI and HPI. They were switched.

### DIFF
--- a/R/similarity_hdi.R
+++ b/R/similarity_hdi.R
@@ -12,6 +12,6 @@ similarity_hdi <- function(graph, v1, v2, ...){
 
   score <- igraph::cocitation(graph, v = v1)
   score <- score[, v2]
-  score <- score / outer(deg[v1], deg[v2], pmin)
+  score <- score / outer(deg[v1], deg[v2], pmax)
   score
 }

--- a/R/similarity_hpi.R
+++ b/R/similarity_hpi.R
@@ -12,6 +12,6 @@ similarity_hpi <- function(graph, v1, v2, ...){
 
   score <- igraph::cocitation(graph, v = v2)
   score <- score[, v2]
-  score <- score / outer(deg[v1], deg[v2], pmax)
+  score <- score / outer(deg[v1], deg[v2], pmin)
   score
 }


### PR DESCRIPTION
Hi.

So maybe I am mistaken, but while taking a peek at the implementation of HDI and HPI, I noticed their implementations are switched/reversed.

HDI is Depressed because the cardinality of common neighbours is divided by the maximum  vertex cardinality of the pair. This is why it depresses it, isn't it?

And HPI is Promoted because it is divided by the minimum of them.

However, in the implementation you are using pmax and pmin in the wrong cases. (pmin for HDI and pmax for HPI).

This pull request aims to fix this reversal. 